### PR TITLE
fix: fixed the quizItem import in quizzes.tsx in mobile_client

### DIFF
--- a/apps/mobile_client/app/(tabs)/quizzes.tsx
+++ b/apps/mobile_client/app/(tabs)/quizzes.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { StyleSheet, ViewStyle, TextStyle, Text, View, Pressable, ScrollView, PressableStateCallbackType } from 'react-native';
 import { MMKV } from 'react-native-mmkv';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { QuizItem } from '../../../../packages/types/quiz';
+import { QuizItem } from '../../../../packages/types/index';
 import quizDataFile from '../../assets/quizData.json';
 
 interface SelectedAnswers {

--- a/apps/mobile_client/app/(tabs)/quizzes.tsx
+++ b/apps/mobile_client/app/(tabs)/quizzes.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { StyleSheet, ViewStyle, TextStyle, Text, View, Pressable, ScrollView, PressableStateCallbackType } from 'react-native';
 import { MMKV } from 'react-native-mmkv';
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { QuizItem } from '../../../../packages/types/index';
+import { QuizItem } from '@aarti-app/types';
 import quizDataFile from '../../assets/quizData.json';
 
 interface SelectedAnswers {


### PR DESCRIPTION
I have fixed the quizItem import in quizzes.tsx to work with the packages/types/index.ts file.