### PR TITLE
fix: Fix MMKV Storage Access During Server-Side Rendering

### DIFF
--- a/apps/mobile_client/app/(tabs)/profile.tsx
+++ b/apps/mobile_client/app/(tabs)/profile.tsx
@@ -3,8 +3,8 @@ import { useState, useEffect } from 'react';
 import { Colors } from '@/constants/Colors';
 import ProgressBar from '../../components/ProgressBar';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
-import { generalQuestionsStorage, quizData } from './quizzes';
-import { settingsStorage } from '../_layout';
+import { getGeneralQuestionsStorage, quizData } from './quizzes';
+import { getSettingsStorage } from '../_layout';
 
 // TODO:
 // fix child key console warning
@@ -15,6 +15,16 @@ import { settingsStorage } from '../_layout';
 
 export default function ProfileScreen() {
   const [activeTab, setActiveTab] = useState<'quiz' | 'resource'>('quiz'); // valid options: quiz, resource
+  const [username, setUsername] = useState<string>('Loading...');
+
+  useEffect(() => {
+    // Load username from storage
+    const storage = getSettingsStorage();
+    const storedUsername = storage.getString("username");
+    if (storedUsername) {
+      setUsername(storedUsername);
+    }
+  }, []);
 
   return (
     <View style={styles.container}>
@@ -25,7 +35,7 @@ export default function ProfileScreen() {
 
       <View style={styles.user}>
         <FontAwesome name="user-circle" size={170} color="black" />
-        <Text style={styles.text}>{`${settingsStorage.getString("username")}`}</Text>
+        <Text style={styles.text}>{username}</Text>
       </View>
 
       <View style={styles.statsSelection}>
@@ -100,7 +110,8 @@ const tempResourceProgress = () => 36;
 
 const totalQuestions = () => quizData.length;
 const totalCompleted = () => {
-  const completed = generalQuestionsStorage.getString('completedQuestions');
+  const storage = getGeneralQuestionsStorage();
+  const completed = storage.getString('completedQuestions');
   if (completed) return JSON.parse(completed).length;
   else return 0;
 };

--- a/apps/mobile_client/app/_layout.tsx
+++ b/apps/mobile_client/app/_layout.tsx
@@ -12,9 +12,17 @@ import { useColorScheme } from '@/hooks/useColorScheme';
 // Prevent the splash screen from auto-hiding before asset loading is complete.
 SplashScreen.preventAutoHideAsync();
 
-// initialize default settings
-export const settingsStorage = new MMKV();
-settingsStorage.set("username", "Example User");
+// Storage instance - will be initialized in useEffect
+let settingsStorage: MMKV | null = null;
+
+// Function to get settings storage instance
+export const getSettingsStorage = () => {
+  if (!settingsStorage) {
+    settingsStorage = new MMKV();
+    settingsStorage.set("username", "Example User");
+  }
+  return settingsStorage;
+};
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
@@ -26,6 +34,8 @@ export default function RootLayout() {
 
   useEffect(() => {
     if (loaded) {
+      // Initialize storage after fonts are loaded
+      getSettingsStorage();
       setAppIsReady(true);
     }
   }, [loaded]);


### PR DESCRIPTION
When starting my code I was getting this error.

Error on the web
<img width="1835" height="787" alt="image" src="https://github.com/user-attachments/assets/0bb63d93-ec6b-47b0-80d3-5e2bcfe235a2" />
Terminal error
<img width="873" height="172" alt="image" src="https://github.com/user-attachments/assets/b317f6e9-b7da-4fdc-b877-8f3f8d0d4b9e" />

This occurred because:
1. MMKV storage instances were being created at the module level (outside React components)
2. Storage was being accessed directly in component render functions
3. Server-side rendering tried to execute these storage operations before the app was properly initialized


So I moved all MMKV storage initialization and access into React lifecycle methods to ensure they only run on the client side.


